### PR TITLE
Move undertow jwa and servlet test under react repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <slf4j.version>1.7.5</slf4j.version>
         <vertx.version>2.0.2-final</vertx.version>
         <jetty.version>9.1.1.v20140108</jetty.version>
+        <undertow.version>1.0.8.Final</undertow.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -117,6 +118,18 @@
                 <groupId>org.eclipse.jetty.websocket</groupId>
                 <artifactId>websocket-client</artifactId>
                 <version>${jetty.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.undertow</groupId>
+                <artifactId>undertow-core</artifactId>
+                <version>${undertow.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.undertow</groupId>
+                <artifactId>undertow-websockets-jsr</artifactId>
+                <version>${undertow.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/react-jwa1/pom.xml
+++ b/react-jwa1/pom.xml
@@ -34,5 +34,13 @@
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>javax-websocket-server-impl</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-websockets-jsr</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/react-jwa1/src/test/java/io/react/jwa/JettyJwaServerWebSocketTest.java
+++ b/react-jwa1/src/test/java/io/react/jwa/JettyJwaServerWebSocketTest.java
@@ -32,7 +32,7 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.websocket.jsr356.server.deploy.WebSocketServerContainerInitializer;
 import org.junit.Test;
 
-public class JwaServerWebSocketTest extends ServerWebSocketTestTemplate {
+public class JettyJwaServerWebSocketTest extends ServerWebSocketTestTemplate {
 
     Server server;
 

--- a/react-jwa1/src/test/java/io/react/jwa/UndertowJwaServerWebSocketTest.java
+++ b/react-jwa1/src/test/java/io/react/jwa/UndertowJwaServerWebSocketTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2013-2014 Donghwan Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.react.jwa;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import io.react.Action;
+import io.react.ServerWebSocket;
+import io.react.test.ServerWebSocketTestTemplate;
+import io.undertow.Undertow;
+import io.undertow.servlet.Servlets;
+import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.DeploymentManager;
+import io.undertow.websockets.jsr.WebSocketDeploymentInfo;
+
+import javax.servlet.ServletException;
+import javax.websocket.Session;
+import javax.websocket.server.ServerEndpointConfig;
+
+import org.junit.Test;
+
+public class UndertowJwaServerWebSocketTest extends ServerWebSocketTestTemplate {
+
+	Undertow server;
+
+	@Override
+	protected void startServer() throws ServletException {
+		ServerEndpointConfig config = new JwaBridge("/test").websocketAction(new Action<ServerWebSocket>() {
+			@Override
+			public void on(ServerWebSocket ws) {
+				performer.serverAction().on(ws);
+			}
+		})
+		.config();
+		
+		DeploymentInfo builder = Servlets.deployment()
+			.setClassLoader(UndertowJwaServerWebSocketTest.class.getClassLoader())
+			.setContextPath("/")
+			.addServletContextAttribute(WebSocketDeploymentInfo.ATTRIBUTE_NAME,  new WebSocketDeploymentInfo().addEndpoint(config))
+			.setDeploymentName("test.war");
+		
+		DeploymentManager manager = Servlets.defaultContainer().addDeployment(builder);
+        manager.deploy();
+        
+		server = Undertow.builder()
+			.addHttpListener(port, "localhost")
+			.setHandler(manager.start())
+			.build();
+		server.start();
+	}
+	
+	@Test
+	public void unwrap() {
+		performer.serverAction(new Action<ServerWebSocket>() {
+			@Override
+			public void on(ServerWebSocket ws) {
+				assertThat(ws.unwrap(Session.class), instanceOf(Session.class));
+				performer.start();
+			}
+		})
+		.connect();
+	}
+
+	@Override
+	protected void stopServer() {
+		server.stop();
+	}
+
+}

--- a/react-servlet3/pom.xml
+++ b/react-servlet3/pom.xml
@@ -38,5 +38,13 @@
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>javax-websocket-server-impl</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-websockets-jsr</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/react-servlet3/src/test/java/io/react/servlet/JettyServletServerHttpExchangeTest.java
+++ b/react-servlet3/src/test/java/io/react/servlet/JettyServletServerHttpExchangeTest.java
@@ -33,7 +33,7 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.junit.Ignore;
 import org.junit.Test;
 
-public class ServletServerHttpExchangeTest extends ServerHttpExchangeTestTemplate {
+public class JettyServletServerHttpExchangeTest extends ServerHttpExchangeTestTemplate {
 
     Server server;
 

--- a/react-servlet3/src/test/java/io/react/servlet/UndertowServletServerHttpExchangeTest.java
+++ b/react-servlet3/src/test/java/io/react/servlet/UndertowServletServerHttpExchangeTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2013-2014 Donghwan Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.react.servlet;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import io.react.Action;
+import io.react.ServerHttpExchange;
+import io.react.test.ServerHttpExchangeTestTemplate;
+import io.undertow.Undertow;
+import io.undertow.servlet.Servlets;
+import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.DeploymentManager;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class UndertowServletServerHttpExchangeTest extends ServerHttpExchangeTestTemplate {
+
+	Undertow server;
+
+	@Override
+	protected void startServer() throws Exception {
+		DeploymentInfo builder = Servlets.deployment()
+			.setClassLoader(UndertowServletServerHttpExchangeTest.class.getClassLoader())
+			.setContextPath("/")
+			.addServletContextAttribute("performer", performer)
+			.addListener(Servlets.listener(UndertowServletContextListener.class))
+			.setDeploymentName("test.war");
+		
+		DeploymentManager manager = Servlets.defaultContainer().addDeployment(builder);
+        manager.deploy();
+        
+		server = Undertow.builder()
+			.addHttpListener(port, "localhost")
+			.setHandler(manager.start())
+			.build();
+		server.start();
+	}
+
+	@Override
+	protected void stopServer() throws Exception {
+		server.stop();
+	}
+
+	@Test
+	public void unwrap() {
+		performer.serverAction(new Action<ServerHttpExchange>() {
+			@Override
+			public void on(ServerHttpExchange http) {
+				assertThat(http.unwrap(HttpServletRequest.class), instanceOf(HttpServletRequest.class));
+				assertThat(http.unwrap(HttpServletResponse.class), instanceOf(HttpServletResponse.class));
+				performer.start();
+			}
+		})
+		.send();
+	}
+	
+	@Override
+	@Test
+	@Ignore
+	public void closeAction_by_client() {}
+	
+	public static class UndertowServletContextListener implements ServletContextListener {
+
+		@Override
+		public void contextInitialized(ServletContextEvent event) {
+			final ServletContext servletContext = event.getServletContext();
+			new ServletBridge(servletContext, "/test").httpAction(new Action<ServerHttpExchange>() {
+				@Override
+				public void on(ServerHttpExchange http) {
+					Performer performer = (Performer) servletContext.getAttribute("performer"); 
+					performer.serverAction().on(http);
+				}
+			});
+		}
+
+		@Override
+		public void contextDestroyed(ServletContextEvent event) {}
+		
+	}
+	
+}


### PR DESCRIPTION
As we have discussed https://github.com/Atmosphere/react/issues/30, I've moved some test projects to react from [wes-servlet3-test](https://github.com/flowersinthesand/wes-servlet3-test/) and [wes-jwa1-test](https://github.com/flowersinthesand/wes-jwa1-test/).

But I could only move undertow tests. Here are issues.
- glassfish and tomcat artifacts have the collision with javax-websocket-server-impl artifact from org.eclipse.jetty.websocket group. It seems that the artifact scan classpath and do something and it brings the collision. I have no idea.
- tomcat 7 and tomcat 8 share the same package so they bring the confusion in the classpath. The same issue applies to jetty 8 and 9 and glassfish 3 and 4. Do you have any idea?
